### PR TITLE
Fixed api search error.

### DIFF
--- a/notaso/restapi/views.py
+++ b/notaso/restapi/views.py
@@ -222,7 +222,7 @@ class SearchViewSet(viewsets.ReadOnlyModelViewSet):
             qs = self.queryset[:10]
 
         # Switch between paginated or standard style responses
-        page = self.paginate_queryset(self.queryset)
+        page = self.paginate_queryset(qs)
         if page is not None:
             serializer = self.get_serializer(page, many=True)
             return self.get_paginated_response(serializer.data)


### PR DESCRIPTION
El search de la versión v1 no estaba funcionando correctamente por que siempre devolvía el self.queryset (en vez del queryset con los resultados de los keywords).